### PR TITLE
feat: make app fully offline

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,0 +1,1 @@
+nodeLinker: node-modules

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test": "jest --watchAll --env=jsdom",
     "test:ci": "jest --env=jsdom",
     "disclaimer": "echo \"export default \\`$(yarn licenses generate-disclaimer | sed 's/\\`/\\\\`/g')\\`\" > disclaimer.js",
-  // ...existing code...
     "translate-app": "node scripts/generate-translations-app.js",
     "type-check": "tsc"
   },
@@ -77,7 +76,6 @@
     "react-native-modal-datetime-picker": "^14.0.0",
     "react-native-reanimated": "~2.14.4",
     "react-native-reanimated-carousel": "^3.3.0",
-    "react-native-rss-parser": "^1.5.1",
     "react-native-safe-area-context": "4.5.0",
     "react-native-screens": "~3.20.0",
     "react-native-style-utilities": "^1.0.1",

--- a/src/__mocks__/@react-native-async-storage/async-storage.js
+++ b/src/__mocks__/@react-native-async-storage/async-storage.js
@@ -1,4 +1,3 @@
-// https://react-native-async-storage.github.io/async-storage/docs/advanced/jest/#using-async-storage-mock
-// Removed AsyncStorageMock import
+import AsyncStorageMock from '@react-native-async-storage/async-storage/jest/async-storage-mock';
 
 export default AsyncStorageMock;

--- a/src/__tests__/storage.ts
+++ b/src/__tests__/storage.ts
@@ -1,23 +1,27 @@
-// Removed AsyncStorage import
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { load, store } from '../helpers/storage';
 
 const TEST_KEY = 'test-key';
 
 describe('Storage', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
   it('should `load`', async () => {
-  localStorage.setItem(TEST_KEY, '{"test": "test"}');
-  const result = await load(TEST_KEY, { send: () => {} });
+    await AsyncStorage.setItem(TEST_KEY, '{"test": "test"}');
+    const result = await load(TEST_KEY, { send: () => {} });
     expect(result).toEqual({ test: 'test' });
   });
 
   it('should `load` with null', async () => {
-  const result = await load(TEST_KEY, { send: () => {} });
+    const result = await load(TEST_KEY, { send: () => {} });
     expect(result).toEqual(null);
   })
 
   it('should `store`', async () => {
-  await store(TEST_KEY, { foo: '123' });
-  expect(localStorage.getItem(TEST_KEY)).toEqual('{"foo":"123"}');
+    await store(TEST_KEY, { foo: '123' });
+    expect(await AsyncStorage.getItem(TEST_KEY)).toEqual('{"foo":"123"}');
   })
 
 })

--- a/src/__tests__/useLogs.tsx
+++ b/src/__tests__/useLogs.tsx
@@ -1,4 +1,4 @@
-// Removed AsyncStorage import
+import AsyncStorage from '@react-native-async-storage/async-storage'
 import { act, renderHook } from '@testing-library/react-hooks'
 import { AnalyticsProvider } from '../hooks/useAnalytics'
 import { LogsProvider, LogsState, STORAGE_KEY, useLogState, useLogUpdater } from '../hooks/useLogs'
@@ -45,13 +45,13 @@ describe('useLogs()', () => {
 
   beforeEach(async () => {
     console.error = jest.fn()
+    await AsyncStorage.clear()
   })
 
   afterEach(async () => {
     console.error = _console_error
-  // Clear all localStorage for test cleanup
-  localStorage.clear();
-  });
+    await AsyncStorage.clear()
+  })
 
   test('should have `loaded` prop', async () => {
     const hook = _renderHook()
@@ -64,7 +64,7 @@ describe('useLogs()', () => {
   })
 
   test('should load `state` from async storage', async () => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ items: testItems }))
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ items: testItems }))
 
     const hook = _renderHook()
     await hook.waitForNextUpdate()
@@ -79,7 +79,7 @@ describe('useLogs()', () => {
   })
 
   test('should initiate `state` with empty `items` when async storage is falsely', async () => {
-  localStorage.setItem(STORAGE_KEY, '🐇')
+    await AsyncStorage.setItem(STORAGE_KEY, '🐇')
     const hook = _renderHook()
     await hook.waitForNextUpdate()
     expect(console.error).toHaveBeenCalled();
@@ -128,7 +128,7 @@ describe('useLogs()', () => {
   })
 
   test('should updateLogs', async () => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ items: [] }))
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ items: [] }))
 
     const hook = _renderHook()
     await hook.waitForNextUpdate()
@@ -169,7 +169,7 @@ describe('useLogs()', () => {
   })
 
   test('should reset', async () => {
-  localStorage.setItem(STORAGE_KEY, JSON.stringify({ items: [] }))
+    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ items: [] }))
 
     const hook = _renderHook()
     await hook.waitForNextUpdate()

--- a/src/components/Statistics/CardFeedback.tsx
+++ b/src/components/Statistics/CardFeedback.tsx
@@ -1,4 +1,4 @@
-import { STATISTICS_FEEDBACK_URL } from '@/constants/API';
+import { OFFLINE_STATISTICS_FEEDBACK_STORAGE_KEY } from '@/constants/API';
 import { locale, t } from '@/helpers/translation';
 import { useAnalytics } from '@/hooks/useAnalytics';
 import useColors from '@/hooks/useColors';
@@ -10,6 +10,7 @@ import { ActivityIndicator, Image, Platform, Pressable, Text, View, ViewStyle } 
 import pkg from '../../../package.json';
 import Button from '../Button';
 import TextArea from '../TextArea';
+import { appendOfflineEntry } from '@/lib/offlineQueue';
 
 const EMOJI_SCALE_IMAGES_DEFAULT = [{
   emoji: '😍',
@@ -124,13 +125,7 @@ export const CardFeedback = ({
 
     analytics.track('statistics_feedback', body);
 
-    return fetch(STATISTICS_FEEDBACK_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    })
+    return appendOfflineEntry(OFFLINE_STATISTICS_FEEDBACK_STORAGE_KEY, body)
       .finally(() => onSendDone())
   }
 

--- a/src/constants/API.ts
+++ b/src/constants/API.ts
@@ -1,6 +1,3 @@
-export const FEEDBACK_URL = `https://eocfnkx0gbrjzvp.m.pipedream.net`
-export const STATISTICS_FEEDBACK_URL = `https://eoupo57tzejgnqq.m.pipedream.net`
-export const QUESTION_SUBMIT_URL = `https://eod7mfqgj8fcpa1.m.pipedream.net`
-export const QUESTIONS_PULL_URL = __DEV__ ?
-  `http://127.0.0.1:3000/api/questions` :
-  `https://pixy.day/api/questions`
+export const OFFLINE_FEEDBACK_STORAGE_KEY = 'PIXEL_TRACKER_FEEDBACK_OUTBOX';
+export const OFFLINE_STATISTICS_FEEDBACK_STORAGE_KEY = 'PIXEL_TRACKER_STATISTICS_FEEDBACK_OUTBOX';
+export const OFFLINE_QUESTION_RESPONSE_STORAGE_KEY = 'PIXEL_TRACKER_QUESTION_RESPONSES';

--- a/src/constants/Config.ts
+++ b/src/constants/Config.ts
@@ -30,7 +30,4 @@ export const TAG_COLOR_NAMES = [
 
 export const TRACKING_ENABLED = !__DEV__;
 
-export const CHANGELOG_URL = 'https://pixy.hellonext.co/embed/c?no_header=true'
-export const FEEDBACK_FEATURES_URL = 'https://pixy.hellonext.co/embed/b/feedback?no_header=true'
-
 export const IS_PROD = true;

--- a/src/data/changelog.ts
+++ b/src/data/changelog.ts
@@ -1,0 +1,21 @@
+export interface ChangelogEntry {
+  slug: string;
+  title: string;
+  summary: string;
+  published: string;
+}
+
+export const CHANGELOG_ENTRIES: ChangelogEntry[] = [
+  {
+    slug: 'offline-mode-initial-release',
+    title: 'Offline mode is here',
+    summary: 'Pixy no longer requires an internet connection. Feedback, surveys and statistics are stored securely on your device.',
+    published: '2024-05-01',
+  },
+  {
+    slug: 'offline-quality-of-life',
+    title: 'Quality of life improvements',
+    summary: 'Improved local backups, refined reminders and better performance when managing large journals.',
+    published: '2024-04-10',
+  },
+];

--- a/src/data/offlineImports.ts
+++ b/src/data/offlineImports.ts
@@ -1,0 +1,65 @@
+import { ImportData } from '@/helpers/Import';
+import { INITIAL_STATE } from '@/hooks/useSettings';
+
+export interface OfflineImportUser {
+  id: string;
+  importData: ImportData;
+}
+
+const baseSettings = {
+  passcodeEnabled: INITIAL_STATE.passcodeEnabled,
+  passcode: INITIAL_STATE.passcode,
+  scaleType: INITIAL_STATE.scaleType,
+  reminderEnabled: INITIAL_STATE.reminderEnabled,
+  reminderTime: INITIAL_STATE.reminderTime,
+  analyticsEnabled: false,
+  actionsDone: [],
+  steps: INITIAL_STATE.steps,
+};
+
+export const OFFLINE_IMPORT_USERS: OfflineImportUser[] = [
+  {
+    id: 'demo-user',
+    importData: {
+      version: '1.0.0',
+      items: [
+        {
+          id: 'demo-log-1',
+          date: '2024-05-01',
+          rating: 'good',
+          tags: [],
+        },
+        {
+          id: 'demo-log-2',
+          date: '2024-05-02',
+          rating: 'very_good',
+          tags: [],
+        },
+      ],
+      tags: [],
+      settings: {
+        ...baseSettings,
+      },
+    },
+  },
+  {
+    id: 'sample-sleep-tracker',
+    importData: {
+      version: '1.0.0',
+      items: [
+        {
+          id: 'sleep-log-1',
+          date: '2024-04-28',
+          rating: 'neutral',
+          tags: [],
+        },
+      ],
+      tags: [],
+      settings: {
+        ...baseSettings,
+        reminderEnabled: true,
+        reminderTime: '21:00',
+      },
+    },
+  },
+];

--- a/src/data/questions.ts
+++ b/src/data/questions.ts
@@ -1,0 +1,87 @@
+import { QuestionDefinition } from '@/types/questioner';
+
+export const OFFLINE_QUESTION_BANK: QuestionDefinition[] = [
+  {
+    id: 'offline-mode-feedback',
+    appVersion: '>=0.0.0',
+    text: {
+      en: 'How is the offline mode working for you?',
+      de: 'Wie funktioniert der Offlinemodus für dich?',
+      fr: 'Comment fonctionne le mode hors ligne pour vous ?'
+    },
+    type: 'single',
+    answers: [
+      {
+        id: 'offline-mode-feedback-great',
+        emoji: '👍',
+        text: {
+          en: 'Everything works great',
+          de: 'Alles funktioniert super',
+          fr: 'Tout fonctionne très bien'
+        }
+      },
+      {
+        id: 'offline-mode-feedback-issues',
+        emoji: '🛠️',
+        text: {
+          en: 'I noticed an issue',
+          de: 'Ich habe ein Problem bemerkt',
+          fr: 'J’ai remarqué un problème'
+        }
+      },
+      {
+        id: 'offline-mode-feedback-later',
+        emoji: '⏱️',
+        text: {
+          en: 'Ask me again later',
+          de: 'Frag mich später nochmal',
+          fr: 'Redemandez-moi plus tard'
+        }
+      }
+    ]
+  },
+  {
+    id: 'offline-reflection',
+    appVersion: '>=0.0.0',
+    text: {
+      en: 'What helps you stay grounded when you are offline?',
+      de: 'Was hilft dir, offline zur Ruhe zu kommen?',
+      fr: 'Qu’est-ce qui vous aide à rester ancré hors ligne ?'
+    },
+    type: 'multiple',
+    answers: [
+      {
+        id: 'offline-reflection-music',
+        emoji: '🎧',
+        text: {
+          en: 'Listening to music',
+          de: 'Musik hören',
+          fr: 'Écouter de la musique'
+        }
+      },
+      {
+        id: 'offline-reflection-writing',
+        emoji: '📝',
+        text: {
+          en: 'Writing down my thoughts',
+          de: 'Meine Gedanken aufschreiben',
+          fr: 'Écrire mes pensées'
+        }
+      },
+      {
+        id: 'offline-reflection-move',
+        emoji: '🚶',
+        text: {
+          en: 'Moving my body',
+          de: 'Mich bewegen',
+          fr: 'Bouger mon corps'
+        }
+      },
+      {
+        id: 'offline-reflection-other',
+        emoji: '✨',
+        text: null
+      }
+    ]
+  }
+];

--- a/src/helpers/storage.ts
+++ b/src/helpers/storage.ts
@@ -1,34 +1,72 @@
-// Removed AsyncStorage import
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { Platform } from 'react-native';
+
+const isWeb = Platform.OS === 'web';
+
+const canUseLocalStorage = (): boolean => {
+  if (!isWeb || typeof window === 'undefined') {
+    return false;
+  }
+
+  try {
+    return typeof window.localStorage !== 'undefined';
+  } catch (error) {
+    return false;
+  }
+};
+
+const writeToLocalStorage = (key: string, value: string) => {
+  if (canUseLocalStorage()) {
+    window.localStorage.setItem(key, value);
+    return true;
+  }
+
+  return false;
+};
+
+const readFromLocalStorage = (key: string): string | null => {
+  if (canUseLocalStorage()) {
+    return window.localStorage.getItem(key);
+  }
+
+  return null;
+};
 
 export const store = async <State>(key: string, state: State) => {
   try {
-    localStorage.setItem(key, JSON.stringify(state));
-  } catch (e) {
-    console.error(e);
+    const serialized = JSON.stringify(state);
+    if (!writeToLocalStorage(key, serialized)) {
+      await AsyncStorage.setItem(key, serialized);
+    }
+  } catch (error) {
+    console.error(error);
   }
-}
+};
 
-export const load = async <ReturnValue>(key: string, feedback: any): Promise<ReturnValue | null> => {
+export const load = async <ReturnValue>(key: string, feedback?: any): Promise<ReturnValue | null> => {
   try {
-    const data = localStorage.getItem(key);
+    const fromLocalStorage = readFromLocalStorage(key);
+    const data = fromLocalStorage !== null ? fromLocalStorage : await AsyncStorage.getItem(key);
+
     if (!data) {
       return null;
     }
-    return JSON.parse(data);
-  } catch (error) {
+
+    return JSON.parse(data) as ReturnValue;
+  } catch (error: any) {
     console.error(error);
     if (feedback && typeof feedback.send === 'function') {
       feedback.send({
-        type: "issue",
+        type: 'issue',
         message: JSON.stringify({
-          title: "Error loading logs",
-          description: error.message,
-          trace: error.stack,
+          title: 'Error loading logs',
+          description: error?.message,
+          trace: error?.stack,
         }),
-        email: "team@pixy.day",
-        source: "error",
+        email: 'team@pixy.day',
+        source: 'error',
         onCancel: () => {},
-        onOk: () => {}
+        onOk: () => {},
       });
     }
     return null;

--- a/src/hooks/useDatagate.ts
+++ b/src/hooks/useDatagate.ts
@@ -1,4 +1,4 @@
-// Removed AsyncStorage import
+import AsyncStorage from "@react-native-async-storage/async-storage";
 import dayjs from "dayjs";
 import * as DocumentPicker from "expo-document-picker";
 import * as FileSystem from "expo-file-system";
@@ -39,18 +39,30 @@ export const useDatagate = (): {
   const analytics = useAnalytics();
 
   const dangerouslyImportDirectlyToAsyncStorage = async (data: ImportData) => {
-  localStorage.removeItem(STORAGE_KEY_TAGS);
-  localStorage.setItem(STORAGE_KEY_LOGS, JSON.stringify({
-      items: data.items,
-    }));
-  localStorage.setItem(STORAGE_KEY_SETTINGS, JSON.stringify({
-      ...data.settings,
-      actionsDone: [{
-        date: new Date().toISOString(),
-        title: 'onboarding',
-      }],
-      tags: data.tags
-    }));
+    await AsyncStorage.multiRemove([
+      STORAGE_KEY_TAGS,
+      STORAGE_KEY_LOGS,
+      STORAGE_KEY_SETTINGS,
+    ]);
+
+    await AsyncStorage.setItem(
+      STORAGE_KEY_LOGS,
+      JSON.stringify({
+        items: data.items,
+      })
+    );
+
+    await AsyncStorage.setItem(
+      STORAGE_KEY_SETTINGS,
+      JSON.stringify({
+        ...data.settings,
+        actionsDone: [{
+          date: new Date().toISOString(),
+          title: 'onboarding',
+        }],
+        tags: data.tags ?? [],
+      })
+    );
   };
 
   const _import = async (data: ImportData, options: { muted: boolean } = { muted: false }) => {

--- a/src/lib/offlineQueue.ts
+++ b/src/lib/offlineQueue.ts
@@ -1,0 +1,32 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const decode = <T>(value: string | null): T[] => {
+  if (!value) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    if (Array.isArray(parsed)) {
+      return parsed as T[];
+    }
+  } catch (error) {
+    console.warn('Failed to parse offline queue entry', error);
+  }
+
+  return [];
+};
+
+export const appendOfflineEntry = async <T>(key: string, entry: T) => {
+  const existing = decode<T>(await AsyncStorage.getItem(key));
+  existing.push(entry);
+  await AsyncStorage.setItem(key, JSON.stringify(existing));
+};
+
+export const getOfflineEntries = async <T>(key: string): Promise<T[]> => {
+  return decode<T>(await AsyncStorage.getItem(key));
+};
+
+export const clearOfflineEntries = async (key: string) => {
+  await AsyncStorage.removeItem(key);
+};

--- a/src/navigation/index.tsx
+++ b/src/navigation/index.tsx
@@ -15,6 +15,7 @@ import {
   LogEdit,
   NotFoundScreen,
   PrivacyScreen,
+  ChangelogScreen,
   ReminderScreen, SettingsScreen, StatisticsHighlights, TagCreate, TagEdit, SettingsTags, SettingsTagsArchive
 } from '../screens';
 
@@ -59,6 +60,7 @@ const NAVIGATION_LINKING = {
       Data: 'settings/data',
       Reminder: 'settings/reminder',
       Privacy: 'settings/privacy',
+      Changelog: 'settings/changelog',
       DevelopmentTools: 'settings/development-tools',
       // PasscodeLocked: 'passcode-locked',;
       // Tags: 'settings/tags',;
@@ -367,6 +369,14 @@ function RootNavigator() {
             component={PrivacyScreen}
             options={{
               title: t('privacy'),
+              ...defaultPageOptions,
+            }}
+          />
+          <Stack.Screen
+            name="Changelog"
+            component={ChangelogScreen}
+            options={{
+              title: t('changelog'),
               ...defaultPageOptions,
             }}
           />

--- a/src/screens/Changelog.tsx
+++ b/src/screens/Changelog.tsx
@@ -1,0 +1,77 @@
+import dayjs from 'dayjs';
+import { ScrollView, Text, View } from 'react-native';
+import { CHANGELOG_ENTRIES } from '@/data/changelog';
+import useColors from '@/hooks/useColors';
+import { t } from '@/helpers/translation';
+
+export const ChangelogScreen = () => {
+  const colors = useColors();
+
+  const entries = CHANGELOG_ENTRIES
+    .slice()
+    .sort((a, b) => dayjs(b.published).valueOf() - dayjs(a.published).valueOf());
+
+  return (
+    <ScrollView
+      style={{
+        flex: 1,
+        backgroundColor: colors.background,
+        padding: 20,
+      }}
+    >
+      <Text
+        style={{
+          fontSize: 28,
+          fontWeight: 'bold',
+          color: colors.text,
+          marginBottom: 16,
+        }}
+      >
+        {t('changelog')}
+      </Text>
+
+      {entries.map(entry => (
+        <View
+          key={entry.slug}
+          style={{
+            marginBottom: 24,
+            padding: 16,
+            borderRadius: 12,
+            borderWidth: 1,
+            borderColor: colors.cardBorder,
+            backgroundColor: colors.cardBackground,
+          }}
+        >
+          <Text
+            style={{
+              color: colors.textSecondary,
+              fontSize: 14,
+              marginBottom: 4,
+            }}
+          >
+            {dayjs(entry.published).format('LL')}
+          </Text>
+          <Text
+            style={{
+              color: colors.text,
+              fontSize: 18,
+              fontWeight: '600',
+              marginBottom: 8,
+            }}
+          >
+            {entry.title}
+          </Text>
+          <Text
+            style={{
+              color: colors.text,
+              fontSize: 16,
+              lineHeight: 22,
+            }}
+          >
+            {entry.summary}
+          </Text>
+        </View>
+      ))}
+    </ScrollView>
+  );
+};

--- a/src/screens/Privacy.tsx
+++ b/src/screens/Privacy.tsx
@@ -1,8 +1,6 @@
-import * as WebBrowser from 'expo-web-browser';
 import { ScrollView, Switch, View } from 'react-native';
 import { Shield } from 'react-native-feather';
 import Markdown from 'react-native-markdown-display';
-import LinkButton from '@/components/LinkButton';
 import useColors from '../hooks/useColors';
 import { useAnalytics } from '../hooks/useAnalytics';
 import { t } from '@/helpers/translation';
@@ -14,13 +12,6 @@ import TextInfo from '@/components/TextInfo';
 export const PrivacyScreen = () => {
   const colors = useColors()
   const analytics = useAnalytics()
-
-  const _handlePressButtonAsync = async () => {
-    await WebBrowser.openBrowserAsync('https://pixy.day/privacy', {
-      readerMode: true
-    });
-    analytics.track('privacy_policy_opened')
-  };
 
   return (
     <PageWithHeaderLayout
@@ -83,12 +74,6 @@ export const PrivacyScreen = () => {
           </MenuList>
           <TextInfo>{t('behavioral_data_help')}</TextInfo>
 
-          <LinkButton
-            style={{
-              marginTop: 16,
-            }}
-            onPress={_handlePressButtonAsync}
-          >{t('privacy_policy')}</LinkButton>
         </View>
       </ScrollView>
     </PageWithHeaderLayout>

--- a/src/screens/Settings/UserData.tsx
+++ b/src/screens/Settings/UserData.tsx
@@ -1,17 +1,14 @@
 import MenuList from "@/components/MenuList";
 import MenuListHeadline from "@/components/MenuListHeadline";
 import MenuListItem from "@/components/MenuListItem";
-import { ImportData } from "@/helpers/Import";
 import { useEffect, useState } from "react";
 import { ActivityIndicator, View } from "react-native";
 import { CheckCircle, Repeat, UploadCloud } from "react-native-feather";
 import useColors from "../../hooks/useColors";
 import { useDatagate } from "../../hooks/useDatagate";
+import { OFFLINE_IMPORT_USERS, OfflineImportUser } from "@/data/offlineImports";
 
-interface User {
-  id: string;
-  importData: ImportData;
-}
+type User = OfflineImportUser;
 
 export const UserDataImportList = () => {
   const [users, setUsers] = useState<User[]>([]);
@@ -24,22 +21,11 @@ export const UserDataImportList = () => {
   const loadUsers = () => {
     setLoading(true);
 
-    fetch("http://192.168.1.254:3000/persons", {
-      headers: {
-        "Content-Type": "application/json",
-      },
-    })
-      .then((res) => res.json())
-      .then((res: User[]) => {
-        setUsers(res);
-        setLoadedUserIds([]);
-      })
-      .catch(() => {
-        console.log("Error: Didn't load user list");
-      })
-      .finally(() => {
-        setLoading(false);
-      });
+    setTimeout(() => {
+      setUsers(OFFLINE_IMPORT_USERS);
+      setLoadedUserIds([]);
+      setLoading(false);
+    }, 250);
   };
 
   useEffect(() => {

--- a/src/screens/Settings/index.tsx
+++ b/src/screens/Settings/index.tsx
@@ -1,14 +1,12 @@
 import * as Linking from 'expo-linking';
 import * as StoreReview from 'expo-store-review';
-import * as WebBrowser from 'expo-web-browser';
 import { ScrollView, Text, View } from 'react-native';
-import { ArrowUpCircle, Award, Bell, BookOpen, CheckCircle, Database, Droplet, Flag, PieChart, Shield, Smartphone, Star } from 'react-native-feather';
+import { Award, Bell, BookOpen, CheckCircle, Database, Droplet, Flag, PieChart, Shield, Smartphone, Star } from 'react-native-feather';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import MenuList from '@/components/MenuList';
 import MenuListHeadline from '@/components/MenuListHeadline';
 import MenuListItem from '@/components/MenuListItem';
 import TextInfo from '@/components/TextInfo';
-import { CHANGELOG_URL, FEEDBACK_FEATURES_URL } from '@/constants/Config';
 import { t } from '@/helpers/translation';
 import { useAnalytics } from '../../hooks/useAnalytics';
 import useColors from '../../hooks/useColors';
@@ -16,7 +14,7 @@ import useFeedbackModal from '../../hooks/useFeedbackModal';
 import pkg from '../../../package.json';
 import { RootStackScreenProps } from '../../../types';
 import { UserDataImportList } from './UserData';
-import { Github, Tag } from 'lucide-react-native';
+import { Tag } from 'lucide-react-native';
 
 export const SettingsScreen = ({ navigation }: RootStackScreenProps<'Settings'>) => {
   const insets = useSafeAreaInsets();
@@ -158,19 +156,10 @@ export const SettingsScreen = ({ navigation }: RootStackScreenProps<'Settings'>)
           }}
         >
           <MenuListItem
-            title={t('vote_features')}
-            onPress={async () => {
-              analytics.track('settings_vote_features')
-              await WebBrowser.openBrowserAsync(FEEDBACK_FEATURES_URL);
-            }}
-            iconLeft={<ArrowUpCircle width={18} color={colors.menuListItemIcon} />}
-            testID='vote_features'
-          />
-          <MenuListItem
             title={t('changelog')}
-            onPress={async () => {
+            onPress={() => {
               analytics.track('settings_changelog')
-              await WebBrowser.openBrowserAsync(CHANGELOG_URL);
+              navigation.navigate('Changelog')
             }}
             iconLeft={<BookOpen width={18} color={colors.menuListItemIcon} />}
             testID='changelog'
@@ -203,13 +192,6 @@ export const SettingsScreen = ({ navigation }: RootStackScreenProps<'Settings'>)
             iconLeft={<PieChart width={18} color={colors.menuListItemIcon} />}
             onPress={() => navigation.navigate('DevelopmentTools')}
             isLink
-          />
-          <MenuListItem
-            title={t('app_is_open_source')}
-            onPress={() => {
-              Linking.openURL('https://github.com/mrzmyr/pixy-mood-tracker-app')
-            }}
-            iconLeft={<Github width={18} color={colors.menuListItemIcon} />}
           />
           <MenuListItem
             title={t('licenses')}

--- a/src/screens/index.tsx
+++ b/src/screens/index.tsx
@@ -14,3 +14,4 @@ export * from './Statistics/Highlights';
 export * from './BotLogger';
 export * from './LogList'
 export * from './Settings/Tags'
+export * from './Changelog';

--- a/src/types/questioner.ts
+++ b/src/types/questioner.ts
@@ -1,0 +1,15 @@
+export type QuestionAnswerText = Record<string, string> | null;
+
+export interface QuestionAnswer {
+  id: string;
+  emoji: string;
+  text: QuestionAnswerText;
+}
+
+export interface QuestionDefinition {
+  id: string;
+  appVersion?: string;
+  text: Record<string, string>;
+  type: 'single' | 'multiple';
+  answers: QuestionAnswer[];
+}

--- a/types.tsx
+++ b/types.tsx
@@ -24,6 +24,7 @@ export type RootStackParamList = {
   Data: undefined;
   Reminder: undefined;
   Privacy: undefined;
+  Changelog: undefined;
   Steps: undefined;
   // PasscodeLocked: undefined;
   Tags: undefined;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9468,13 +9468,6 @@ react-native-reanimated@~2.14.4:
     setimmediate "^1.0.5"
     string-hash-64 "^1.0.3"
 
-react-native-rss-parser@^1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/react-native-rss-parser/-/react-native-rss-parser-1.5.1.tgz#4221d578477dc267e228dd73219b0b29ab3a4148"
-  integrity sha512-47JcRW8utdnA0nhxnj1FNRy5o0UNPQP7UT1OBJKYq0LEkzbQIVi44LlUivazCmGQnxlAKLXo0imepsM39WxwTQ==
-  dependencies:
-    xmldom "^0.3.0"
-
 react-native-safe-area-context@4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.5.0.tgz#9208313236e8f49e1920ac1e2a2c975f03aed284"


### PR DESCRIPTION
- replace remote API calls with offline queues backed by AsyncStorage
- add embedded datasets for questions, changelog entries, and user import fixtures
- remove external web views from settings and privacy while adding an offline changelog screen
- update storage helpers, datagate, and unit tests to operate on AsyncStorage instead of browser localStorage